### PR TITLE
A few minor updates

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,3 +11,4 @@ Sphinx==1.8.1
 twine==1.12.1
 webexteamssdk==1.0.3
 white>=0.1.2
+requests-mock

--- a/tests/teams_mock.py
+++ b/tests/teams_mock.py
@@ -67,6 +67,64 @@ class MockTeamsAPI:
         return json.dumps(data)
 
     @classmethod
+    def incoming_membership_fail(cls):
+        data = {
+            'id': 'newwebhook',
+            'name': 'My Awesome Webhook',
+            'targetUrl': 'https://example.com/mywebhook',
+            'resource': 'memberships',
+            'event': 'created',
+            'orgId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNkYzlh',
+            'createdBy': 'fdsafdsf',
+            'appId': 'asdfasdfsadf',
+            'ownedBy': 'creator',
+            'status': 'active',
+            'created': '2018-09-13T19:35:51.248Z',
+            'actorId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNkYzlh',
+            'data': {
+                'id': 'incoming_membership_id',
+                'roomId': 'some_room_id',
+                'personId': 'some_person_id',
+                'personEmail': 'matt@example.com',
+                'personDisplayName': 'Matt',
+                'personOrgId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNk',
+                'isModerator': False,
+                'isMonitor': False,
+                'created': '2018-09-13T19:35:58.803Z'
+            }
+        }
+        return json.dumps(data)
+
+    @classmethod
+    def incoming_membership_pass(cls):
+        data = {
+            'id': 'newwebhook',
+            'name': 'My Awesome Webhook',
+            'targetUrl': 'https://example.com/mywebhook',
+            'resource': 'memberships',
+            'event': 'created',
+            'orgId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNkYzlh',
+            'createdBy': 'fdsafdsf',
+            'appId': 'asdfasdfsadf',
+            'ownedBy': 'creator',
+            'status': 'active',
+            'created': '2018-09-13T19:35:51.248Z',
+            'actorId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNkYzlh',
+            'data': {
+                'id': 'incoming_membership_id',
+                'roomId': 'some_room_id',
+                'personId': 'some_person_id',
+                'personEmail': 'matt@cisco.com',
+                'personDisplayName': 'Matt',
+                'personOrgId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNk',
+                'isModerator': False,
+                'isMonitor': False,
+                'created': '2018-09-13T19:35:58.803Z'
+            }
+        }
+        return json.dumps(data)
+
+    @classmethod
     def get_message_help(cls):
         data = {
             "id": "some_message_id",

--- a/tests/test_webexteamsbot.py
+++ b/tests/test_webexteamsbot.py
@@ -168,6 +168,91 @@ class TeamsBotTests(unittest.TestCase):
         self.assertIn(b"I understand the following commands", resp.data)
 
     @requests_mock.mock()
+    def test_process_incoming_membership_check_sender_fail(self, m):
+        m.get('https://api.ciscospark.com/v1/webhooks',
+              json=MockTeamsAPI.list_webhooks())
+        m.post('https://api.ciscospark.com/v1/webhooks',
+               json=MockTeamsAPI.create_webhook())
+        m.post('//api.ciscospark.com/v1/messages', json={})
+        bot_email = "test@test.com"
+        teams_token = "somefaketoken"
+        bot_url = "http://fakebot.com"
+        bot_app_name = "testbot"
+        # Create a new bot
+        bot = TeamsBot(bot_app_name,
+                       teams_bot_token=teams_token,
+                       teams_bot_url=bot_url,
+                       teams_bot_email=bot_email,
+                       debug=True,
+                       webhook_resource="memberships",
+                       webhook_event="all")
+
+        # Add new command
+        bot.add_command('memberships',
+                        '*',
+                        self.check_membership)
+        bot.testing = True
+        self.app = bot.test_client()
+
+        resp = self.app.post('/',
+                             data=MockTeamsAPI.incoming_membership_fail(),
+                             content_type="application/json")
+        self.assertEqual(resp.status_code, 200)
+        print(resp.data)
+        self.assertIn(b"failed", resp.data)
+
+    @requests_mock.mock()
+    def test_process_incoming_membership_check_sender_pass(self, m):
+        m.get('https://api.ciscospark.com/v1/webhooks',
+              json=MockTeamsAPI.list_webhooks())
+        m.post('https://api.ciscospark.com/v1/webhooks',
+               json=MockTeamsAPI.create_webhook())
+        m.post('//api.ciscospark.com/v1/messages', json={})
+        bot_email = "test@test.com"
+        teams_token = "somefaketoken"
+        bot_url = "http://fakebot.com"
+        bot_app_name = "testbot"
+        # Create a new bot
+        bot = TeamsBot(bot_app_name,
+                       teams_bot_token=teams_token,
+                       teams_bot_url=bot_url,
+                       teams_bot_email=bot_email,
+                       debug=True,
+                       webhook_resource="memberships",
+                       webhook_event="all")
+
+        # Add new command
+        bot.add_command('memberships',
+                        '*',
+                        self.check_membership)
+        bot.testing = True
+        self.app = bot.test_client()
+
+        resp = self.app.post('/',
+                             data=MockTeamsAPI.incoming_membership_pass(),
+                             content_type="application/json")
+        self.assertEqual(resp.status_code, 200)
+        print(resp.data)
+        self.assertIn(b"success", resp.data)
+
+    def check_membership(self, ob, incoming_msg):
+        """
+        Sample function to do some action.
+        :param incoming_msg: The incoming message object from Spark
+        :param ob: Spark API object
+        :return: A text or markdown based reply
+        """
+
+        whitelist = ["cisco.com"]
+        pemail = incoming_msg["data"]["personEmail"]
+        pdom = pemail.split("@")[1]
+
+        if pdom in whitelist:
+            return "success"
+        else:
+            return "failed"
+
+    @requests_mock.mock()
     def test_process_incoming_message_match_command(self, m):
         m.get("//api.ciscospark.com/v1/people/me", json=MockTeamsAPI.me())
         m.get(

--- a/webexteamsbot/webexteamsbot.py
+++ b/webexteamsbot/webexteamsbot.py
@@ -81,6 +81,9 @@ class TeamsBot(Flask):
             "/help": {"help": "Get help.", "callback": self.send_help},
         }
 
+        # Set default help message
+        self.help_message = "Hello!  I understand the following commands:  \n"
+
         # Flask Application URLs
         # Basic Health Check for Flask Application
         self.add_url_rule("/health", "health", self.health)
@@ -256,7 +259,7 @@ class TeamsBot(Flask):
         # Find the command that was sent, if any
         command = ""
         for c in self.commands.items():
-            if message.text.find(c[0]) != -1:
+            if message.text.lower().find(c[0]) != -1:
                 command = c[0]
                 sys.stderr.write("Found command: " + command + "\n")
                 # If a command was found, stop looking for others
@@ -296,7 +299,7 @@ class TeamsBot(Flask):
         :param callback: The function to run when this command is given
         :return:
         """
-        self.commands[command] = {"help": help_message, "callback": callback}
+        self.commands[command.lower()] = {"help": help_message, "callback": callback}
 
     def remove_command(self, command):
         """
@@ -328,6 +331,13 @@ class TeamsBot(Flask):
         )
         self.default_action = "/greeting"
 
+    def set_help_message(self, msg):
+        """
+        Configure the banner for the help message. Command list will be appended to this later.
+        :return:
+        """
+        self.help_message = msg
+
     # *** Default Commands included in Bot
     def send_help(self, post_data):
         """
@@ -335,9 +345,8 @@ class TeamsBot(Flask):
         :param post_data:
         :return:
         """
-        message = "Hello!  "
-        message += "I understand the following commands:  \n"
-        for c in self.commands.items():
+        message = self.help_message
+        for c in sorted(self.commands.items()):
             if c[1]["help"][0] != "*":
                 message += "* **%s**: %s \n" % (c[0], c[1]["help"])
         return message

--- a/webexteamsbot/webexteamsbot.py
+++ b/webexteamsbot/webexteamsbot.py
@@ -170,6 +170,12 @@ class TeamsBot(Flask):
                 if h.name == searchname:
                     sys.stderr.write("Found existing webhook.  Updating it.\n")
                     wh = h
+                elif h.name == name:
+                    # check for webhook name with original naming convention
+                    #  if found, let's update to the new naming convetion
+                    if w["resource"] == "messages" and w["event"] == "created":
+                        sys.stderr.write("Found old webhook.  Updating it.\n")
+                        wh = h
 
             # No existing webhook found, create new one
             # we reached the end of the generator w/o finding matching webhook

--- a/webexteamsbot/webexteamsbot.py
+++ b/webexteamsbot/webexteamsbot.py
@@ -248,7 +248,8 @@ class TeamsBot(Flask):
 
         if post_data["resource"] != "messages":
             if post_data["resource"] in self.commands.keys():
-                reply = self.commands[post_data["resource"]]["callback"](self, post_data)
+                api = WebexTeamsAPI(access_token=self.teams_bot_token)
+                reply = self.commands[post_data["resource"]]["callback"](api, post_data)
             else:
                 return ""
         elif post_data["resource"] == "messages":

--- a/webexteamsbot/webexteamsbot.py
+++ b/webexteamsbot/webexteamsbot.py
@@ -122,7 +122,8 @@ class TeamsBot(Flask):
         # Setup the Teams Connection
         globals()["teams"] = WebexTeamsAPI(access_token=self.teams_bot_token)
         globals()["webhook"] = self.setup_webhook(
-            self.teams_bot_name, self.teams_bot_url, self.webhook_resource, self.webhook_event
+            self.teams_bot_name, self.teams_bot_url,
+            self.webhook_resource, self.webhook_event
         )
         sys.stderr.write("Configuring Webhook. \n")
         sys.stderr.write("Webhook ID: " + globals()["webhook"].id + "\n")
@@ -157,13 +158,15 @@ class TeamsBot(Flask):
                 event=wh_event,
             )
 
-        # if we have an existing webhook, delete and recreate (can't update resource/event)
+        # if we have an existing webhook, delete and recreate
+        #   (can't update resource/event)
         else:
             # Need try block because if there are NO webhooks it throws error
             try:
                 wh = self.teams.webhooks.delete(webhookId=wh.id)
                 wh = self.teams.webhooks.create(
-                    name=name, targetUrl=targeturl, resource=wh_resource, event=wh_event
+                    name=name, targetUrl=targeturl,
+                    resource=wh_resource, event=wh_event
                 )
             # https://github.com/CiscoDevNet/ciscoteamsapi/blob/master/ciscoteamsapi/api/webhooks.py#L237
             except Exception as e:
@@ -249,7 +252,8 @@ class TeamsBot(Flask):
         if post_data["resource"] != "messages":
             if post_data["resource"] in self.commands.keys():
                 api = WebexTeamsAPI(access_token=self.teams_bot_token)
-                reply = self.commands[post_data["resource"]]["callback"](api, post_data)
+                p = post_data
+                reply = self.commands[p["resource"]]["callback"](api, p)
             else:
                 return ""
         elif post_data["resource"] == "messages":
@@ -316,7 +320,8 @@ class TeamsBot(Flask):
         :param callback: The function to run when this command is given
         :return:
         """
-        self.commands[command.lower()] = {"help": help_message, "callback": callback}
+        self.commands[command.lower()] = {"help": help_message,
+                                          "callback": callback}
 
     def remove_command(self, command):
         """
@@ -334,7 +339,7 @@ class TeamsBot(Flask):
         :return:
         """
         cmd_loc = text.find(command)
-        message = text[cmd_loc + len(command) :]
+        message = text[cmd_loc + len(command):]
         return message
 
     def set_greeting(self, callback):
@@ -350,7 +355,8 @@ class TeamsBot(Flask):
 
     def set_help_message(self, msg):
         """
-        Configure the banner for the help message. Command list will be appended to this later.
+        Configure the banner for the help message.
+        Command list will be appended to this later.
         :return:
         """
         self.help_message = msg

--- a/webexteamsbot/webexteamsbot.py
+++ b/webexteamsbot/webexteamsbot.py
@@ -39,14 +39,15 @@ class TeamsBot(Flask):
         :param teams_bot_email: Teams Bot Email Address
         :param teams_bot_url: WebHook URL for this Bot
         :param default_action: What action to take if no command found.
-                               Defaults to /help
+                Defaults to /help
         :param webhook_resource: What resource to trigger webhook on
-                               Defaults to messages
+                Defaults to messages
         :param webhook_event: What resource event to trigger webhook on
-                               Defaults to created
-        :param webhook_resource_event: List of dicts for which resource/events to create webhooks for.
-                                        [{"resource": "messages", "event": "created"},
-                                         {"resource": "attachmentActions", "event": "created"}]
+                Defaults to created
+        :param webhook_resource_event: List of dicts for which resource/events
+                to create webhooks for.
+                [{"resource": "messages", "event": "created"},
+                {"resource": "attachmentActions", "event": "created"}]
         :param debug: boolean value for debut messages
         """
 
@@ -131,21 +132,25 @@ class TeamsBot(Flask):
         globals()["teams"] = WebexTeamsAPI(access_token=self.teams_bot_token)
         globals()["webhook"] = self.setup_webhook(
             self.teams_bot_name, self.teams_bot_url,
-            self.webhook_resource, self.webhook_event, self.webhook_resource_event
+            self.webhook_resource, self.webhook_event,
+            self.webhook_resource_event
         )
         sys.stderr.write("Configuring Webhook. \n")
         for w in globals()["webhook"]:
             sys.stderr.write("Webhook ID: " + w.id + "\n")
 
     # noinspection PyMethodMayBeStatic
-    def setup_webhook(self, name, targeturl, wh_resource, wh_event, wh_resource_event):
+    def setup_webhook(self, name, targeturl, wh_resource, wh_event,
+                      wh_resource_event):
         """
         Setup Teams WebHook to send incoming messages to this bot.
         :param name: Name of the WebHook
         :param targeturl: Target URL for WebHook
-        :param wh_resource: WebHook Resource (attachmentActions, memberships, messages, rooms)
+        :param wh_resource: WebHook Resource
+                (attachmentActions, memberships, messages, rooms)
         :param wh_event: WebHook Event (created, updated, deleted)
-        :param wh_resource_event: List of Dicts including which resource/event mappings to use.
+        :param wh_resource_event: List of Dicts including which
+                resource/event mappings to use.
         :return: WebHook
         """
         # Get a list of current webhooks
@@ -167,7 +172,7 @@ class TeamsBot(Flask):
                     wh = h
 
             # No existing webhook found, create new one
-            # we reached the end of the generator w/o finding a matching webhook
+            # we reached the end of the generator w/o finding matching webhook
             if wh is None:
                 sys.stderr.write("Creating new webhook.\n")
                 wh = self.teams.webhooks.create(
@@ -180,7 +185,7 @@ class TeamsBot(Flask):
             # if we have an existing webhook, delete and recreate
             #   (can't update resource/event)
             else:
-                # Need try block because if there are NO webhooks it throws error
+                # try block because if there are NO webhooks it throws error
                 try:
                     wh = self.teams.webhooks.delete(webhookId=wh.id)
                     wh = self.teams.webhooks.create(
@@ -270,10 +275,11 @@ class TeamsBot(Flask):
         room_id = post_data["data"]["roomId"]
 
         if post_data["resource"] != "messages":
-            if post_data["resource"].lower() in self.commands.keys():
+            cmdcheck = post_data["resource"].lower()
+            if cmdcheck in self.commands.keys():
                 api = WebexTeamsAPI(access_token=self.teams_bot_token)
                 p = post_data
-                reply = self.commands[p["resource"].lower()]["callback"](api, p)
+                reply = self.commands[cmdcheck]["callback"](api, p)
             else:
                 return ""
         elif post_data["resource"] == "messages":


### PR DESCRIPTION
* Add set_help_message method to allow customization of help message banner
* Remove case sensitivity in commands
* Add sorting of commands when showing help
* Add unit tests / fix flake formatting issues
* Update to allow bot to handle more than messages:created; tested with memberships:all

Details around the last one:
I was in need of a bot that could monitor memberships data, so I extended this one to do that.

With the changes in the PR, the default behavior is still in tact. However, here is an example of how you would monitor membership changes:

In your main code, when you create an instance of the bot, add the "webhook_resource" and "webhook_event" parameters:
```
bot = TeamsBot(bot_app_name, teams_bot_token=spark_token,
               teams_bot_url=bot_url, teams_bot_email=bot_email, debug=True,
               webhook_resource="memberships", webhook_event="all")
```

Then, add a new command for the resource you want to monitor:
`bot.add_command('memberships', '*', check_memberships)
`

Finally, add a function to handle that command. For example, I needed the bot (which is assigned to the room as a moderator) to be able to remove anyone from a room who is not in a set of whitelisted domains (i.e., to ensure that a room stays "internal-only"). This function has an additional parameter (api in my example), which is used to directly access the WebexTeamsSDK object.
```
def check_memberships(api, incoming_msg):
    wl_dom = os.getenv("WHITELIST_DOMAINS")
    if wl_dom.find("[") < 0:
        wl_dom = '["' + wl_dom + '"]'
        wl_dom = wl_dom.replace(",", '","')

    if wl_dom and incoming_msg["event"] != "deleted":
        pemail = incoming_msg["data"]["personEmail"]
        pid = incoming_msg["data"]["personId"]
        pdom = pemail.split("@")[1]
        plist = json.loads(wl_dom)
        print(pemail, pdom, plist)
        if pdom in plist or pemail == bot_email:
            # membership check succeeded
            return ""
        else:
            # membership check failed
            print("membership failed. deleting " + incoming_msg["data"]["id"])
            api.memberships.delete(incoming_msg["data"]["id"])
            api.messages.create(toPersonId=pid, markdown="You were automatically removed from the space because "
                                     "it is restricted to internal employees.")
            return "'" + pemail + "' was automatically removed from this space; it is restricted to only internal users."

    return ""
```